### PR TITLE
Use List<T> instead of IList<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ public class GraphQLSettings
 {
     public Func<HttpContext, Task<object>> BuildUserContext { get; set; }
     public object Root { get; set; }
-    public IList<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
+    public List<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
 }
 ```
 


### PR DESCRIPTION
Since the example is using `.AddRange(rules)` we need a List<T> instead of IList<T>