### PR TITLE
Return the user context directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ public static void UseGraphQLWithAuth(this IApplicationBuilder app)
                 User = ctx.User
             };
 
-            return Task.FromResult(userContext);
+            return userContext;
         }
     };
 


### PR DESCRIPTION
When returning a Task from BuildUserContext `Field<StringGraphType>("name").AuthorizeWith("SomePolicy");`isn't working