### PR TITLE
Add AuthorizeWith support off ConnectionBuilder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ branches:
 
 install:
   - ps: Install-Product node LTS
-  - ps: choco install dotnetcore-sdk --no-progress --confirm --version 2.2.104
+  - ps: choco install dotnetcore-sdk --no-progress --confirm --version 3.1.401
   - node --version
   - npm --version
   - dotnet --version

--- a/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
+++ b/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
@@ -16,6 +16,10 @@
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package references for .NET Core 3" Condition="'$(IsNetCore3OnwardsTarget)' == 'True'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
+++ b/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
@@ -1,25 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GraphQL.NewtonsoftJson" Version="3.0.0-preview-1648" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup Label="Package references for .NET Core 3" Condition="'$(IsNetCore3OnwardsTarget)' == 'True'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Authorization/AuthorizationMetadataExtensions.cs
+++ b/src/GraphQL.Authorization/AuthorizationMetadataExtensions.cs
@@ -47,6 +47,13 @@ namespace GraphQL.Authorization
             return builder;
         }
 
+        public static ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(
+            this ConnectionBuilder<TSourceType> builder, string policy)
+        {
+            builder.FieldType.AuthorizeWith(policy);
+            return builder;
+        }
+
         public static List<string> GetPolicies(this IProvideMetadata type)
         {
             return type.GetMetadata(PolicyKey, new List<string>());

--- a/src/Harness/Harness.csproj
+++ b/src/Harness/Harness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Harness/Harness.csproj
+++ b/src/Harness/Harness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.0.0-preview-1648" />
-    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="3.5.0-alpha0027" />
-    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.5.0-alpha0027" />
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="GraphQL" Version="3.0.0-preview-1712" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="3.5.0-alpha0072" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="3.5.0-alpha0072" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.5.0-alpha0072" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Harness/Startup.cs
+++ b/src/Harness/Startup.cs
@@ -75,7 +75,7 @@ namespace Harness
             var validationRules = app.ApplicationServices.GetServices<IValidationRule>();
 
             app.UseGraphQL<ISchema>("/graphql");
-            app.UseGraphiQLServer(new GraphiQLOptions());
+            app.UseGraphiQLServer();
         }
     }
 }

--- a/src/Harness/Startup.cs
+++ b/src/Harness/Startup.cs
@@ -63,12 +63,12 @@ namespace Harness
             services.AddGraphQL(options =>
             {
                 options.ExposeExceptions = true;
-            }).AddUserContextBuilder(context => new GraphQLUserContext { User = context.User });
-
-            services.AddMvc();
+            })
+            .AddSystemTextJson()
+            .AddUserContextBuilder(context => new GraphQLUserContext { User = context.User });
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseDeveloperExceptionPage();
 
@@ -76,8 +76,6 @@ namespace Harness
 
             app.UseGraphQL<ISchema>("/graphql");
             app.UseGraphiQLServer(new GraphiQLOptions());
-
-            app.UseMvc();
         }
     }
 }


### PR DESCRIPTION
This is analog to PR [290](https://github.com/graphql-dotnet/server/pull/290) in the graphql-dotnet/server repo.

Adds `AuthorizeWith` support for `ConnectionBuilder`.

Provides ability to do the following:
```c#
Connection<MyType>()
    .Name("myTypes")
    .AuthorizeWith("SomePolicy")
    .Resolve(...);
```