### PR TITLE
Multi version targeting of GraphQL.NET

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         graphqlversion:
+          - default
           - 3.0.0
           - 3.1.0
-          - 3.1.3
-          - 3.2.0
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build solution [Release]
         working-directory: src
         run: dotnet build --no-restore -c Release -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
-      - name: Build solution [Debug]
+      - name: Build solution [Debug] with GraphQL version ${{ matrix.graphqlversion }}
         working-directory: src
         run: dotnet build --no-restore -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
       - name: Test solution [Debug]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         graphqlversion:
           - 3.0.0
           - 3.1.0
+          - 3.1.3
           - 4.0.0-preview-17
     steps:
       - name: Checkout source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         graphqlversion:
           - 3.0.0
           - 3.1.0
-          - 3.2.3
+          - 3.1.3
           - 4.0.0-preview-17
     steps:
       - name: Checkout source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         graphqlversion:
-          - 2.4.0
           - 3.0.0
           - 3.1.0
-          - 3.2.0
+          - 4.0.0-preview-17
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
         os: 
           - ubuntu-latest
           - windows-latest
+        graphqlversion:
+          - 3.0.0
+          - 3.1.0
+          - 3.1.3
+          - 3.2.0
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -33,10 +38,10 @@ jobs:
         run: dotnet restore
       - name: Build solution [Release]
         working-directory: src
-        run: dotnet build --no-restore -c Release -p:NoWarn=CS1591
+        run: dotnet build --no-restore -c Release -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
       - name: Build solution [Debug]
         working-directory: src
-        run: dotnet build --no-restore -p:NoWarn=CS1591
+        run: dotnet build --no-restore -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
       - name: Test solution [Debug]
         working-directory: src
         run: dotnet test --no-restore --no-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,9 @@ jobs:
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Install dependencies
+      - name: Install dependencies with GraphQL version ${{ matrix.graphqlversion }}
         working-directory: src
-        run: dotnet restore
+        run: dotnet restore -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
       - name: Build solution [Release]
         working-directory: src
         run: dotnet build --no-restore -c Release -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - default
           - 3.0.0
           - 3.1.0
+          - 3.2.0
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,10 @@ jobs:
       - name: Test solution [Debug]
         working-directory: src
         run: dotnet test --no-restore --no-build
+  all-tests:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: All tests completed successfully
+        run: exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build solution [Release]
         working-directory: src
         run: dotnet build --no-restore -c Release -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
-      - name: Build solution [Debug] with GraphQL version ${{ matrix.graphqlversion }}
+      - name: Build solution [Debug]
         working-directory: src
         run: dotnet build --no-restore -p:NoWarn=CS1591 -p:GraphQLTestVersion=${{ matrix.graphqlversion }}
       - name: Test solution [Debug]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         graphqlversion:
-          - default
+          - 2.4.0
           - 3.0.0
           - 3.1.0
           - 3.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         graphqlversion:
           - 3.0.0
           - 3.1.0
-          - 3.1.3
+          - 3.2.3
           - 4.0.0-preview-17
     steps:
       - name: Checkout source

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(GraphQLTestVersion)' == '' || '$(GraphQLTestVersion)' == 'default'">
+  <PropertyGroup Condition="'$(GraphQLTestVersion)' == '' OR '$(GraphQLTestVersion)' == 'default'">
     <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
   

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,6 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="'$(IsPackable)' == 'true'"/>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(GraphQLTestVersion)' == ''">
+  <PropertyGroup Condition="'$(GraphQLTestVersion)' == '' || '$(GraphQLTestVersion)' == 'default'">
     <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
   

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,9 +15,12 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GraphQLTestVersion)' == ''">
+    <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="'$(IsPackable)' == 'true'"/>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,9 +15,6 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(GraphQLTestVersion)' == '' OR '$(GraphQLTestVersion)' == 'default'">
     <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
   

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,7 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
+++ b/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="..\GraphQL.Authorization\GraphQL.Authorization.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="GraphQL" Version="$(GraphQLTestVersion)" />
+  </ItemGroup>
+  
 </Project>

--- a/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
+++ b/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>$(NoWarn);1591;IDE1006</NoWarn>
+    <GraphQLTestVersion>3.1.3</GraphQLTestVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Authorization/GraphQL.Authorization.csproj
+++ b/src/GraphQL.Authorization/GraphQL.Authorization.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.1.3" />
+    <PackageReference Include="GraphQL" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
If we are not going to have a "mono repo", we should target the oldest compatible version of GraphQL.Net.  For this repo, 3.0.0.  We can run tests against the latest version of GraphQL.Net, however, and this PR is a demonstration of running tests against multiple versions of the GraphQL.Net library.

These changes compile the authorization library to run against >=3.0.0 but then runs tests against all these versions on both windows and ubuntu:
- 3.0.0
- 3.1.0
- 3.1.3
- 4.0.0-preview-17

Locally the tests are configured to run against 3.1.3.

This now is the true benefit of separate repos, where people can select a new version of one component without updating the rest of their references.  (The increased testing is really just a bonus.)

Note: required status checks needs to change to "all-tests"