### PR TITLE
Revert minimum required version of GraphQL.Net to 3.0.0

### DIFF
--- a/src/GraphQL.Authorization/GraphQL.Authorization.csproj
+++ b/src/GraphQL.Authorization/GraphQL.Authorization.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.1.3" />
+    <PackageReference Include="GraphQL" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Nothing in this repo requires 3.1.0 or later.