### PR TITLE
Add GraphQLBuilder method called AddAuthorization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         graphqlversion:
-          - 4.2.0
-          - 4.4.0
+          - 4.6.1
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/src/GraphQL.Authorization.ApiTests/GraphQL.Authorization.approved.txt
+++ b/src/GraphQL.Authorization.ApiTests/GraphQL.Authorization.approved.txt
@@ -68,6 +68,11 @@ namespace GraphQL.Authorization
         public System.Collections.Generic.IEnumerable<string> DisplayValues { get; }
         public System.Threading.Tasks.Task Authorize(GraphQL.Authorization.AuthorizationContext context) { }
     }
+    public static class GraphQLBuilderExtensions
+    {
+        public static void AddAuthorization(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Authorization.AuthorizationSettings> configure) { }
+        public static void AddAuthorization(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Authorization.AuthorizationSettings, System.IServiceProvider> configure) { }
+    }
     public interface IAuthorizationEvaluator
     {
         System.Threading.Tasks.Task<GraphQL.Authorization.AuthorizationResult> Evaluate(System.Security.Claims.ClaimsPrincipal principal, System.Collections.Generic.IDictionary<string, object> userContext, System.Collections.Generic.IReadOnlyDictionary<string, object> inputs, System.Collections.Generic.IEnumerable<string> requiredPolicies);

--- a/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
+++ b/src/GraphQL.Authorization.Tests/GraphQL.Authorization.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5;netcoreapp3.1</TargetFrameworks>
-    <GraphQLTestVersion>4.2.0</GraphQLTestVersion>
+    <GraphQLTestVersion>4.6.0</GraphQLTestVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Authorization/GraphQL.Authorization.csproj
+++ b/src/GraphQL.Authorization/GraphQL.Authorization.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.2.0" />
+    <PackageReference Include="GraphQL" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL.Authorization/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL.Authorization/GraphQLBuilderExtensions.cs
@@ -9,8 +9,8 @@ namespace GraphQL.Authorization
         /// <summary>
         /// Registers <see cref="AuthorizationEvaluator"/> and <see cref="AuthorizationValidationRule"/> within the
         /// dependency injection framework and configures the validation rule to be added to the list of validation rules
-        /// within <see cref="ExecutionOptions.ValidationRules"/> upon document execution.
-        /// Configures authorization settings with the specified configuration delegate.
+        /// within <see cref="ExecutionOptions.ValidationRules"/> and <see cref="ExecutionOptions.CachedDocumentValidationRules"/>
+        /// upon document execution. Configures authorization settings with the specified configuration delegate.
         /// </summary>
         public static void AddAuthorization(this IGraphQLBuilder builder, Action<AuthorizationSettings, IServiceProvider> configure)
         {

--- a/src/GraphQL.Authorization/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL.Authorization/GraphQLBuilderExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using GraphQL.DI;
+
+namespace GraphQL.Authorization
+{
+    /// <inheritdoc cref="GraphQL.GraphQLBuilderExtensions"/>
+    public static class GraphQLBuilderExtensions
+    {
+        /// <summary>
+        /// Registers <see cref="AuthorizationEvaluator"/> and <see cref="AuthorizationValidationRule"/> within the
+        /// dependency injection framework and configures the validation rule to be added to the list of validation rules
+        /// within <see cref="ExecutionOptions.ValidationRules"/> upon document execution.
+        /// Configures authorization settings with the specified configuration delegate.
+        /// </summary>
+        public static void AddAuthorization(this IGraphQLBuilder builder, Action<AuthorizationSettings, IServiceProvider> configure)
+        {
+            builder.TryRegister<IAuthorizationEvaluator, AuthorizationEvaluator>(ServiceLifetime.Singleton);
+            builder.AddValidationRule<AuthorizationValidationRule>(true);
+            builder.Configure(configure);
+        }
+
+        /// <inheritdoc cref="AddAuthorization(IGraphQLBuilder, Action{AuthorizationSettings, IServiceProvider})"/>
+        public static void AddAuthorization(this IGraphQLBuilder builder, Action<AuthorizationSettings> configure)
+        {
+            builder.TryRegister<IAuthorizationEvaluator, AuthorizationEvaluator>(ServiceLifetime.Singleton);
+            builder.AddValidationRule<AuthorizationValidationRule>(true);
+            builder.Configure(configure);
+        }
+    }
+}

--- a/src/Harness/GraphQLAuthExtensions.cs
+++ b/src/Harness/GraphQLAuthExtensions.cs
@@ -9,7 +9,7 @@ namespace Harness
     /// <summary>
     /// Extension methods to add GraphQL authorization into DI container.
     /// </summary>
-    public static class GraphQLAuthExtensions
+    public static class GraphQLAuthExtensions // TODO: remove soon
     {
         /// <summary>
         /// Adds all necessary classes into provided <paramref name="services"/>

--- a/src/Harness/Startup.cs
+++ b/src/Harness/Startup.cs
@@ -39,6 +39,7 @@ namespace Harness
                 return schema;
             });
 
+            // TODO: change to IGraphQLBuilder
             // extension method defined in this project
             services.AddGraphQLAuth((settings, provider) => settings.AddPolicy("AdminPolicy", p => p.RequireClaim("role", "Admin")));
 


### PR DESCRIPTION
Unfortunately until https://github.com/graphql-dotnet/server/pull/602 is merged and released, the builder methods cannot be used within the Harness project because it relies on GraphQL.Server which has not been updated to support `GraphQL.DI.IGraphQLBuilder`.