### PR TITLE
Additional changes for v7 compatibility

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,35 @@
+name: Run code tests
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+    paths:
+      - src/**
+      - .github/workflows/**
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+          source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Install dependencies
+        working-directory: src
+        run: dotnet restore
+      - name: Check formatting
+        working-directory: src
+        run: |
+          dotnet format --no-restore --verify-no-changes --severity warn || (echo "Run 'dotnet format' to fix issues" && exit 1)

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Run code tests
+name: Check formatting
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,6 @@ jobs:
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Disable MSVS Nuget Source # temporary step to investigate https://github.com/graphql-dotnet/graphql-dotnet/issues/2422
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: dotnet nuget disable source 'Microsoft Visual Studio Offline Packages'
       - name: Install dependencies with GraphQL version ${{ matrix.graphqlversion }}
         working-directory: src
         run: dotnet restore -p:GraphQLTestVersion=${{ matrix.graphqlversion }}

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ public class MutationType
 # Known Issues
 
 - It is currently not possible to add a policy to Input objects using Schema first approach.
+
+- Authorization checks are skipped on fragments that are referenced by other fragments

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ public class MutationType
 
 - It is currently not possible to add a policy to Input objects using Schema first approach.
 
-- Authorization checks are skipped on fragments that are referenced by other fragments
+- :warning: Authorization checks are skipped on fragments that are referenced by other fragments :warning:

--- a/README.md
+++ b/README.md
@@ -27,13 +27,23 @@ Note that GitHub requires authentication to consume the feed. See [here](https:/
 # Usage
 
 - Register the authorization classes in your DI container - call `AddAuthorization` on the provided `IGraphQLBuilder` inside `AddGraphQL` extension method.
-- Provide a custom `UserContext` class that implements `IProvideClaimsPrincipal`.
+- Provide a custom `UserContext` class that implements `IProvideClaimsPrincipal` or provide the `ClaimsPrincipal` through `ExecutionOptions.User`.
 - Add policies to the `AuthorizationSettings`.
 - Apply a policy to a GraphType or Field - both implement `IProvideMetadata`:
   - using `AuthorizeWithPolicy(string policy)` extension method
   - or with `AuthorizeAttribute` attribute if using Schema + Handler syntax.
 - The `AuthorizationValidationRule` will run and verify the policies based on the registered policies.
 - You can write your own `IAuthorizationRequirement`.
+
+# Limitations
+
+This authorization framework only supports policy-based authorization. It does not support role-based authorization, or the
+`[AllowAnonymous]` attribute/extension, or the `[Authorize]` attribute/extension indicating authorization is required
+but without specifying a policy. It also does not integrate with ASP.NET Core's authorization framework.
+
+The [GraphQL.Server](https://www.github.com/graphql-dotnet/server) repository contains an authorization rule which has the above
+missing features, intended for use with ASP.NET Core. It may also be tailored with custom authentication code if desired, rather than
+relying on ASP.NET Core's authentication framework.
 
 # Examples
 

--- a/src/GraphQL.Authorization.Tests/AuthorizationValidationRuleTests.cs
+++ b/src/GraphQL.Authorization.Tests/AuthorizationValidationRuleTests.cs
@@ -148,6 +148,19 @@ public class AuthorizationValidationRuleTests : ValidationTestBase
         });
     }
 
+    [Fact(Skip = "This needs to be fixed")]
+    public void nested_fragment_should_fail()
+    {
+        Settings.AddPolicy("AdminPolicy", builder => builder.RequireClaim("admin"));
+
+        ShouldFailRule(config =>
+        {
+            config.Query = "query a { article { ...frag } } query b { article { ...frag } } fragment frag on Article { ...frag2 } fragment frag2 on Article { content }";
+            config.Schema = TypedSchema();
+            config.ValidateResult = result => _ = result.Errors.Single(x => x.Message == $"You are not authorized to run this query.\nRequired claim 'admin' is not present.");
+        });
+    }
+
     [Fact]
     public void nested_type_list_non_null_policy_fail()
     {

--- a/src/GraphQL.Authorization.Tests/ValidationTestBase.cs
+++ b/src/GraphQL.Authorization.Tests/ValidationTestBase.cs
@@ -64,7 +64,7 @@ public class ValidationTestBase
         {
             Schema = config.Schema,
             Document = document,
-            Operation = document.OperationWithName(config.OperationName)!,
+            Operation = document.OperationWithName(config.OperationName) ?? throw new InvalidOperationException("Could not find specified operation"),
             Rules = config.Rules,
             Variables = config.Variables ?? Inputs.Empty,
             UserContext = userContext

--- a/src/GraphQL.Authorization.sln
+++ b/src/GraphQL.Authorization.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 		..\.github\workflows\codeql-analysis.yml = ..\.github\workflows\codeql-analysis.yml
+		..\.github\workflows\format.yml = ..\.github\workflows\format.yml
 		..\.github\workflows\label.yml = ..\.github\workflows\label.yml
 		..\.github\workflows\publish.yml = ..\.github\workflows\publish.yml
 		..\.github\workflows\test.yml = ..\.github\workflows\test.yml

--- a/src/GraphQL.Authorization/AuthorizationValidationRule.cs
+++ b/src/GraphQL.Authorization/AuthorizationValidationRule.cs
@@ -109,10 +109,10 @@ public class AuthorizationValidationRule : IValidationRule
 
         public async ValueTask EnterAsync(ASTNode node, ValidationContext context)
         {
-            if (node is GraphQLOperationDefinition && node == context.Operation)
+            if (node is GraphQLOperationDefinition astType && astType == context.Operation)
             {
                 var type = context.TypeInfo.GetLastType();
-                await AuthorizeAsync(node, type, context).ConfigureAwait(false);
+                await AuthorizeAsync(astType, type, context).ConfigureAwait(false);
             }
 
             if (node is GraphQLObjectField objectFieldAst &&


### PR DESCRIPTION
This PR targets `bump` / PR #254 

- Use `ExecutionOptions.User` for `ClaimsPrincipal` if user context does not implement `IProvideClaimsPrincipal`
- Asynchronous execution of policies, eliminating all calls to `GetAwaiter().GetResult()`
- No API changes
- Add note to readme regarding unsupported features and ASP.NET Core compatibility
- Separate format check from tests
- Add note that this implementation has a critical security flaw

There's really very little code changes; mostly just refactoring.

Tests run locally but don't run because this PR doesn't target `master` or `develop`.

Hide whitespace to reduce the diff