### PR TITLE
Fix security flaw with nested fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,3 @@ public class MutationType
 # Known Issues
 
 - It is currently not possible to add a policy to Input objects using Schema first approach.
-
-- :warning: Authorization checks are skipped on fragments that are referenced by other fragments :warning:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Note that GitHub requires authentication to consume the feed. See [here](https:/
 # Limitations
 
 `@skip` and `@include` directives are ignored; all selected fields of the selected operation will
-be checked for authentication requirements, including referenced fragments. However, other operations
-in the same document will not be checked.
+be checked for authentication requirements, including referenced fragments. (Other operations
+in the same document will correctly be skipped.)
 
 This authorization framework only supports policy-based authorization. It does not support role-based authorization, or the
 `[AllowAnonymous]` attribute/extension, or the `[Authorize]` attribute/extension indicating authorization is required

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Note that GitHub requires authentication to consume the feed. See [here](https:/
 
 # Limitations
 
+`@skip` and `@include` directives are ignored; all selected fields of the selected operation will
+be checked for authentication requirements, including referenced fragments. However, other operations
+in the same document will not be checked.
+
 This authorization framework only supports policy-based authorization. It does not support role-based authorization, or the
 `[AllowAnonymous]` attribute/extension, or the `[Authorize]` attribute/extension indicating authorization is required
 but without specifying a policy. It also does not integrate with ASP.NET Core's authorization framework.

--- a/src/GraphQL.Authorization.Tests/AuthorizationValidationRuleTests.cs
+++ b/src/GraphQL.Authorization.Tests/AuthorizationValidationRuleTests.cs
@@ -148,7 +148,7 @@ public class AuthorizationValidationRuleTests : ValidationTestBase
         });
     }
 
-    [Fact(Skip = "This needs to be fixed")]
+    [Fact]
     public void nested_fragment_should_fail()
     {
         Settings.AddPolicy("AdminPolicy", builder => builder.RequireClaim("admin"));


### PR DESCRIPTION
This targets `bump` but once PR #254 is merged, I can update it to target `master`.  Or it can be merged into `bump`.

This fixes the security flaw where nested fragments are not processed for authentication when there are multiple operations in the document.

It should also run faster than the previous implementation, and reduces the complexity of the implementation.